### PR TITLE
Add repository link to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Metaswitch Networks Ltd"]
 
 description = "A client library for HashiCorp Vault"
 readme = "README.md"
+repository = "https://github.com/Metaswitch/vault-client"
 keywords = ["vault", "tls"]
 categories = ["authentication"]
 license = "Apache-2.0/MIT"


### PR DESCRIPTION
It took me a while to find the repository without this :) This is necessary for the "repository" link to show up on crates.io