### PR TITLE
Migrate vault client and server to hyper v12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,7 @@ vault-api = "0.7.2"
 tempfile = "2.1.5"
 
 [workspace]
+
+members = [
+    "vault-api",
+]

--- a/vault-api/Cargo.toml
+++ b/vault-api/Cargo.toml
@@ -15,17 +15,19 @@ server = ["serde_json", "serde_ignored", "hyper", "iron", "router", "bodyparser"
 #
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
-hyper = {version = "0.10", optional = true}
-hyper-openssl = {version = "0.2", optional = true }
+hyper = {version = "0.12", optional = true}
+hyper-openssl = {version = "0.6", optional = true }
 iron = {version = "0.5", optional = true}
 swagger = "0.7"
 
 # Not required by example server.
 #
 bodyparser = {version = "0.7", optional = true}
-url = "1.5"
+http = "0.1"
+url = "1.7"
 lazy_static = "0.2"
 log = "0.3.0"
+mime = "0.3"
 multipart = {version = "0.13", optional = true}
 router = {version = "0.5", optional = true}
 serde = "1.0"

--- a/vault-api/examples/client.rs
+++ b/vault-api/examples/client.rs
@@ -8,6 +8,7 @@ extern crate swagger;
 #[allow(unused_extern_crates)]
 extern crate uuid;
 extern crate clap;
+extern crate url;
 
 #[allow(unused_imports)]
 use futures::{Future, future, Stream, stream};
@@ -23,6 +24,7 @@ use vault_api::{ApiNoContext, ContextWrapperExt,
                       RenewOwnTokenResponse
                      };
 use clap::{App, Arg};
+use url::Url;
 
 fn main() {
     let matches = App::new("client")
@@ -54,6 +56,8 @@ fn main() {
                            if is_https { "https" } else { "http" },
                            matches.value_of("host").unwrap(),
                            matches.value_of("port").unwrap());
+    let base_url = Url::parse(&base_url).expect("Invalid base url");
+
     let client = if is_https {
         // Using Simple HTTPS
         vault_api::Client::try_new_https(&base_url, "examples/ca.pem")

--- a/vault-api/src/client.rs
+++ b/vault-api/src/client.rs
@@ -1,57 +1,56 @@
 #![allow(unused_extern_crates)]
-extern crate hyper_openssl;
 extern crate chrono;
+extern crate hyper_openssl;
 extern crate url;
 
-
-
-use hyper;
-use hyper::client::IntoUrl;
-use hyper::mime;
-use hyper::header::{Headers, ContentType};
-use hyper::mime::{Mime, TopLevel, SubLevel, Attr, Value};
-use hyper::Url;
 use self::hyper_openssl::openssl;
+use self::hyper_openssl::HttpsConnector;
 use self::url::percent_encoding::{utf8_percent_encode, PATH_SEGMENT_ENCODE_SET, QUERY_ENCODE_SET};
 use futures;
-use futures::{Future, Stream};
 use futures::{future, stream};
+use futures::{Future, Stream};
+use http::header;
+use http::header::{HeaderName, HeaderValue};
+use hyper;
+use hyper::client::connect::Connect;
+use hyper::client::HttpConnector;
+use hyper::Request;
+use mime::Mime;
+use serde::de::Deserialize;
 use std::borrow::Cow;
-use std::io::{Read, Error};
 use std::error;
 use std::fmt;
+use std::io::{Error, Read};
 use std::path::Path;
-use std::sync::Arc;
 use std::str;
+use std::sync::Arc;
 
 use mimetypes;
 
 use serde_json;
 
-
 #[allow(unused_imports)]
-use std::collections::{HashMap, BTreeMap};
+use std::collections::{BTreeMap, HashMap};
 #[allow(unused_imports)]
 use swagger;
 
-use swagger::{Context, ApiError, XSpanId};
+use swagger::{ApiError, Context, XSpanId};
 
-use {Api,
-     SysLeasesRevokePutResponse,
-     GenerateCertResponse,
-     ReadCertResponse,
-     CreateOrphanTokenResponse,
-     CreateTokenResponse,
-     LogInWithTLSCertificateResponse,
-     RenewOwnTokenResponse
-     };
 use models;
+use {
+    Api, CreateOrphanTokenResponse, CreateTokenResponse, GenerateCertResponse,
+    LogInWithTLSCertificateResponse, ReadCertResponse, RenewOwnTokenResponse,
+    SysLeasesRevokePutResponse,
+};
+
+const REQUEST_X_VAULT_TOKEN: &'static str = "X-Vault-Token";
 
 /// Convert input into a base path, e.g. "http://example:123". Also checks the scheme as it goes.
-fn into_base_path<T: IntoUrl>(input: T, correct_scheme: Option<&'static str>) -> Result<String, ClientInitError> {
+fn into_base_path(
+    url: &url::Url,
+    correct_scheme: Option<&'static str>,
+) -> Result<String, ClientInitError> {
     // First convert to Url, since a base path is a subset of Url.
-    let url = input.into_url()?;
-
     let scheme = url.scheme();
 
     // Check the scheme if necessary
@@ -66,64 +65,91 @@ fn into_base_path<T: IntoUrl>(input: T, correct_scheme: Option<&'static str>) ->
     Ok(format!("{}://{}{}", scheme, host, port))
 }
 
-/// A client that implements the API by making HTTP calls out to a server.
-#[derive(Clone)]
-pub struct Client {
-    base_path: String,
-    hyper_client: Arc<Fn() -> hyper::client::Client + Sync + Send>,
+/// Helper function to provide a code block to use `?` in (to be replaced by the `catch` block when it exists).
+fn parse_response<'a, T>(response: &'a (http::response::Parts, hyper::Chunk)) -> Result<T, ApiError>
+where
+    T: Deserialize<'a>,
+{
+    match response.0.status.as_u16() {
+        200 => serde_json::from_slice::<T>(&response.1)
+            .map_err(|e| ApiError(format!("Response was not valid AuthResponse: {}", e))),
+        code => {
+            let debug_body = match str::from_utf8(&response.1) {
+                Ok(body) => Cow::from(body),
+                Err(e) => Cow::from(format!("<Body was not UTF8: {:?}>", e)),
+            };
+            Err(ApiError(format!(
+                "Unexpected response code {}:\n{:?}\n\n{}",
+                code, response.0.headers, debug_body
+            )))
+        }
+    }
 }
 
-impl fmt::Debug for Client {
+/// A client that implements the API by making HTTP calls out to a server.
+#[derive(Clone)]
+pub struct Client<C: Connect + Sync + 'static> {
+    base_path: String,
+    hyper_client: Arc<Fn() -> hyper::client::Client<C, hyper::Body> + Sync + Send>,
+}
+
+impl<C> fmt::Debug for Client<C>
+where
+    C: Connect,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Client {{ base_path: {} }}", self.base_path)
     }
 }
 
-impl Client {
-    pub fn try_new_http<T>(base_path: T) -> Result<Client, ClientInitError>
-        where T: IntoUrl
-    {
+impl<C> Client<C>
+where
+    C: Connect,
+{
+    pub fn try_new_http(base_path: &url::Url) -> Result<Client<HttpConnector>, ClientInitError> {
         Ok(Client {
             base_path: into_base_path(base_path, Some("http"))?,
             hyper_client: Arc::new(hyper::client::Client::new),
         })
     }
 
-    pub fn try_new_https<T, CA>(base_path: T,
-                                ca_certificate: CA)
-                            -> Result<Client, ClientInitError>
-        where T: IntoUrl,
-              CA: AsRef<Path>
+    pub fn try_new_https<CA>(
+        base_path: &url::Url,
+        ca_certificate: CA,
+    ) -> Result<Client<HttpsConnector<HttpConnector>>, ClientInitError>
+    where
+        CA: AsRef<Path>,
     {
         let ca_certificate = ca_certificate.as_ref().to_owned();
 
         let https_hyper_client = move || {
             // SSL implementation
-            let mut ssl = openssl::ssl::SslConnectorBuilder::new(openssl::ssl::SslMethod::tls()).unwrap();
+            let mut ssl =
+                openssl::ssl::SslConnector::builder(openssl::ssl::SslMethod::tls()).unwrap();
 
             // Server authentication
-            ssl.builder_mut().set_ca_file(ca_certificate.clone()).unwrap();
-
-            let ssl = hyper_openssl::OpensslClient::from(ssl.build());
-            let connector = hyper::net::HttpsConnector::new(ssl);
-            hyper::client::Client::with_connector(connector)
+            ssl.set_ca_file(ca_certificate.clone()).unwrap();
+            let http_connector = HttpConnector::new(1);
+            let connector = HttpsConnector::with_connector(http_connector, ssl).unwrap();
+            hyper::client::Client::builder().build(connector)
         };
 
         Ok(Client {
-                base_path: into_base_path(base_path, Some("https"))?,
-                hyper_client: Arc::new(https_hyper_client),
-            })
+            base_path: into_base_path(base_path, Some("https"))?,
+            hyper_client: Arc::new(https_hyper_client),
+        })
     }
 
-    pub fn try_new_https_mutual<T, CA, K, C>(base_path: T,
-                                             ca_certificate: CA,
-                                             client_key: K,
-                                             client_certificate: C)
-                                             -> Result<Client, ClientInitError>
-        where T: IntoUrl,
-              CA: AsRef<Path>,
-              K: AsRef<Path>,
-              C: AsRef<Path>
+    pub fn try_new_https_mutual<CA, K, CC>(
+        base_path: &url::Url,
+        ca_certificate: CA,
+        client_key: K,
+        client_certificate: CC,
+    ) -> Result<Client<HttpsConnector<HttpConnector>>, ClientInitError>
+    where
+        CA: AsRef<Path>,
+        K: AsRef<Path>,
+        CC: AsRef<Path>,
     {
         let ca_certificate = ca_certificate.as_ref().to_owned();
         let client_key = client_key.as_ref().to_owned();
@@ -131,25 +157,28 @@ impl Client {
 
         let https_mutual_hyper_client = move || {
             // SSL implementation
-            let mut ssl = openssl::ssl::SslConnectorBuilder::new(openssl::ssl::SslMethod::tls()).unwrap();
+            let mut ssl =
+                openssl::ssl::SslConnector::builder(openssl::ssl::SslMethod::tls()).unwrap();
 
             // Server authentication
-            ssl.builder_mut().set_ca_file(ca_certificate.clone()).unwrap();
+            ssl.set_ca_file(ca_certificate.clone()).unwrap();
 
             // Client authentication
-            ssl.builder_mut().set_private_key_file(client_key.clone(), openssl::x509::X509_FILETYPE_PEM).unwrap();
-            ssl.builder_mut().set_certificate_chain_file(client_certificate.clone()).unwrap();
-            ssl.builder_mut().check_private_key().unwrap();
+            ssl.set_private_key_file(client_key.clone(), openssl::ssl::SslFiletype::PEM)
+                .unwrap();
+            ssl.set_certificate_chain_file(client_certificate.clone())
+                .unwrap();
+            ssl.check_private_key().unwrap();
 
-            let ssl = hyper_openssl::OpensslClient::from(ssl.build());
-            let connector = hyper::net::HttpsConnector::new(ssl);
-            hyper::client::Client::with_connector(connector)
+            let http_connector = HttpConnector::new(1);
+            let connector = HttpsConnector::with_connector(http_connector, ssl).unwrap();
+            hyper::client::Client::builder().build(connector)
         };
 
         Ok(Client {
-                base_path: into_base_path(base_path, Some("https"))?,
-                hyper_client: Arc::new(https_mutual_hyper_client)
-            })
+            base_path: into_base_path(base_path, Some("https"))?,
+            hyper_client: Arc::new(https_mutual_hyper_client),
+        })
     }
 
     /// Constructor for creating a `Client` by passing in a pre-made `hyper` client.
@@ -161,439 +190,346 @@ impl Client {
     /// The reason for this function's existence is to support legacy test code, which did mocking at the hyper layer.
     /// This is not a recommended way to write new tests. If other reasons are found for using this function, they
     /// should be mentioned here.
-    pub fn try_new_with_hyper_client<T>(base_path: T,
-                                    hyper_client: Arc<Fn() -> hyper::client::Client + Sync + Send>)
-                                    -> Result<Client, ClientInitError>
-        where T: IntoUrl
-    {
+    pub fn try_new_with_hyper_client(
+        base_path: &url::Url,
+        hyper_client: Arc<Fn() -> hyper::client::Client<C, hyper::Body> + Sync + Send>,
+    ) -> Result<Client<C>, ClientInitError> {
         Ok(Client {
             base_path: into_base_path(base_path, None)?,
-            hyper_client: hyper_client
+            hyper_client: hyper_client,
         })
     }
 }
 
-impl Api for Client {
-
-    fn sys_leases_revoke_put(&self, param_x_vault_token: String, param_body: models::RevokeLeaseParameters, context: &Context) -> Box<Future<Item=SysLeasesRevokePutResponse, Error=ApiError> + Send> {
-
-
-        let url = format!(
-            "{}/v1/sys/leases/revoke",
-            self.base_path
-        );
-
+impl<C> Api for Client<C>
+where
+    C: Connect,
+{
+    fn sys_leases_revoke_put(
+        &self,
+        param_x_vault_token: String,
+        param_body: models::RevokeLeaseParameters,
+        context: &Context,
+    ) -> Box<Future<Item = SysLeasesRevokePutResponse, Error = ApiError> + Send> {
+        let url = format!("{}/v1/sys/leases/revoke", self.base_path);
 
         let body = serde_json::to_string(&param_body).expect("impossible to fail to serialize");
 
         let hyper_client = (self.hyper_client)();
-        let request = hyper_client.request(hyper::method::Method::Put, &url);
-        let mut custom_headers = hyper::header::Headers::new();
 
-        let request = request.body(&body);
+        let mut request = Request::put(&url);
 
-        custom_headers.set(ContentType(mimetypes::requests::SYS_LEASES_REVOKE_PUT.clone()));
-        context.x_span_id.as_ref().map(|header| custom_headers.set(XSpanId(header.clone())));
+        request.header(
+            header::CONTENT_TYPE,
+            mimetypes::requests::SYS_LEASES_REVOKE_PUT.clone(),
+        );
+
+        if let Some(ref xspan) = context.x_span_id {
+            let x_span_value = HeaderValue::from_str(xspan).unwrap();
+            request.header("x-span-id", x_span_value);
+        }
 
         // Header parameters
-        header! { (RequestXVaultToken, "X-Vault-Token") => [String] }
-        custom_headers.set(RequestXVaultToken(param_x_vault_token));
+        request.header(REQUEST_X_VAULT_TOKEN, param_x_vault_token);
 
-
-        let request = request.headers(custom_headers);
+        let request = request.body(body.into()).unwrap();
 
         // Helper function to provide a code block to use `?` in (to be replaced by the `catch` block when it exists).
-        fn parse_response(mut response: hyper::client::response::Response) -> Result<SysLeasesRevokePutResponse, ApiError> {
-            match response.status.to_u16() {
-                204 => {
-
-
-                    Ok(SysLeasesRevokePutResponse::Success)
-                },
+        fn parse_response<'a>(
+            response: (http::response::Parts, hyper::Chunk),
+        ) -> Result<SysLeasesRevokePutResponse, ApiError> {
+            match response.0.status.as_u16() {
+                204 => Ok(SysLeasesRevokePutResponse::Success),
                 code => {
-                    let mut buf = [0; 100];
-                    let debug_body = match response.read(&mut buf) {
-                        Ok(len) => match str::from_utf8(&buf[..len]) {
-                            Ok(body) => Cow::from(body),
-                            Err(_) => Cow::from(format!("<Body was not UTF8: {:?}>", &buf[..len].to_vec())),
-                        },
-                        Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
+                    let debug_body = match str::from_utf8(&response.1.as_ref()) {
+                        Ok(body) => Cow::from(body),
+                        Err(e) => Cow::from(format!("<Body was not UTF8: {:?}>", e)),
                     };
-                    Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
-                                         code,
-                                         response.headers,
-                                         debug_body)))
+                    Err(ApiError(format!(
+                        "Unexpected response code {}:\n{:?}\n\n{}",
+                        code, response.0.headers, debug_body
+                    )))
                 }
             }
         }
 
-        let result = request.send().map_err(|e| ApiError(format!("No response received: {}", e))).and_then(parse_response);
-        Box::new(futures::done(result))
+        let f = hyper_client
+            .request(request)
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .and_then(|response| {
+                let (parts, body) = response.into_parts();
+                body.concat2()
+                    .map(|body| (parts, body))
+                    .map_err(|e| ApiError(format!("Failed to read response body: {}", e)))
+            })
+            .and_then(parse_response);
+        Box::new(f)
     }
 
-    fn generate_cert(&self, param_x_vault_token: String, param_mount: String, param_name: String, param_body: models::GenerateCertificateParameters, context: &Context) -> Box<Future<Item=GenerateCertResponse, Error=ApiError> + Send> {
-
-
+    fn generate_cert(
+        &self,
+        param_x_vault_token: String,
+        param_mount: String,
+        param_name: String,
+        param_body: models::GenerateCertificateParameters,
+        context: &Context,
+    ) -> Box<Future<Item = GenerateCertResponse, Error = ApiError> + Send> {
         let url = format!(
             "{}/v1/{mount}/issue/{name}",
-            self.base_path, mount=utf8_percent_encode(&param_mount.to_string(), PATH_SEGMENT_ENCODE_SET), name=utf8_percent_encode(&param_name.to_string(), PATH_SEGMENT_ENCODE_SET)
+            self.base_path,
+            mount = utf8_percent_encode(&param_mount.to_string(), PATH_SEGMENT_ENCODE_SET),
+            name = utf8_percent_encode(&param_name.to_string(), PATH_SEGMENT_ENCODE_SET)
         );
-
 
         let body = serde_json::to_string(&param_body).expect("impossible to fail to serialize");
 
         let hyper_client = (self.hyper_client)();
-        let request = hyper_client.request(hyper::method::Method::Post, &url);
-        let mut custom_headers = hyper::header::Headers::new();
+        let mut request = Request::post(&url);
 
-        let request = request.body(&body);
-
-        custom_headers.set(ContentType(mimetypes::requests::GENERATE_CERT.clone()));
-        context.x_span_id.as_ref().map(|header| custom_headers.set(XSpanId(header.clone())));
-
-        // Header parameters
-        header! { (RequestXVaultToken, "X-Vault-Token") => [String] }
-        custom_headers.set(RequestXVaultToken(param_x_vault_token));
-
-
-        let request = request.headers(custom_headers);
-
-        // Helper function to provide a code block to use `?` in (to be replaced by the `catch` block when it exists).
-        fn parse_response(mut response: hyper::client::response::Response) -> Result<GenerateCertResponse, ApiError> {
-            match response.status.to_u16() {
-                200 => {
-                    let mut buf = String::new();
-                    response.read_to_string(&mut buf).map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
-                    let body = serde_json::from_str::<models::GenerateCertificateResponse>(&buf)?;
-
-
-
-                    Ok(GenerateCertResponse::Success(body))
-                },
-                code => {
-                    let mut buf = [0; 100];
-                    let debug_body = match response.read(&mut buf) {
-                        Ok(len) => match str::from_utf8(&buf[..len]) {
-                            Ok(body) => Cow::from(body),
-                            Err(_) => Cow::from(format!("<Body was not UTF8: {:?}>", &buf[..len].to_vec())),
-                        },
-                        Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
-                    };
-                    Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
-                                         code,
-                                         response.headers,
-                                         debug_body)))
-                }
-            }
+        request.header(
+            header::CONTENT_TYPE,
+            mimetypes::requests::GENERATE_CERT.clone(),
+        );
+        if let Some(ref xspan) = context.x_span_id {
+            let x_span_value = HeaderValue::from_str(xspan).unwrap();
+            request.header("x-span-id", x_span_value);
         }
 
-        let result = request.send().map_err(|e| ApiError(format!("No response received: {}", e))).and_then(parse_response);
-        Box::new(futures::done(result))
+        // Header parameters
+        let x_vault_token = HeaderValue::from_str(param_x_vault_token.as_str()).unwrap();
+        request.header(REQUEST_X_VAULT_TOKEN, x_vault_token);
+
+        let request = request.body(body.into()).unwrap();
+
+        let f = hyper_client
+            .request(request)
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .and_then(|response| {
+                let (parts, body) = response.into_parts();
+                body.concat2()
+                    .map(|body| (parts, body))
+                    .map_err(|e| ApiError(format!("Failed to read response body: {}", e)))
+            })
+            .and_then(|ref x| parse_response(x))
+            .map(|x| GenerateCertResponse::Success(x));
+        Box::new(f)
     }
 
-    fn read_cert(&self, param_mount: String, param_serial: String, context: &Context) -> Box<Future<Item=ReadCertResponse, Error=ApiError> + Send> {
-
-
+    fn read_cert(
+        &self,
+        param_mount: String,
+        param_serial: String,
+        context: &Context,
+    ) -> Box<Future<Item = ReadCertResponse, Error = ApiError> + Send> {
         let url = format!(
             "{}/v1/{mount}/cert/{serial}",
-            self.base_path, mount=utf8_percent_encode(&param_mount.to_string(), PATH_SEGMENT_ENCODE_SET), serial=utf8_percent_encode(&param_serial.to_string(), PATH_SEGMENT_ENCODE_SET)
+            self.base_path,
+            mount = utf8_percent_encode(&param_mount.to_string(), PATH_SEGMENT_ENCODE_SET),
+            serial = utf8_percent_encode(&param_serial.to_string(), PATH_SEGMENT_ENCODE_SET)
         );
-
 
         let hyper_client = (self.hyper_client)();
-        let request = hyper_client.request(hyper::method::Method::Get, &url);
-        let mut custom_headers = hyper::header::Headers::new();
+        let mut request = Request::get(&url);
 
-        context.x_span_id.as_ref().map(|header| custom_headers.set(XSpanId(header.clone())));
-
-
-        let request = request.headers(custom_headers);
-
-        // Helper function to provide a code block to use `?` in (to be replaced by the `catch` block when it exists).
-        fn parse_response(mut response: hyper::client::response::Response) -> Result<ReadCertResponse, ApiError> {
-            match response.status.to_u16() {
-                200 => {
-                    let mut buf = String::new();
-                    response.read_to_string(&mut buf).map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
-                    let body = serde_json::from_str::<models::CertificateResponse>(&buf)?;
-
-
-
-                    Ok(ReadCertResponse::Success(body))
-                },
-                code => {
-                    let mut buf = [0; 100];
-                    let debug_body = match response.read(&mut buf) {
-                        Ok(len) => match str::from_utf8(&buf[..len]) {
-                            Ok(body) => Cow::from(body),
-                            Err(_) => Cow::from(format!("<Body was not UTF8: {:?}>", &buf[..len].to_vec())),
-                        },
-                        Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
-                    };
-                    Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
-                                         code,
-                                         response.headers,
-                                         debug_body)))
-                }
-            }
+        if let Some(ref xspan) = context.x_span_id {
+            let x_span_value = HeaderValue::from_str(xspan).unwrap();
+            request.header("x-span-id", x_span_value);
         }
 
-        let result = request.send().map_err(|e| ApiError(format!("No response received: {}", e))).and_then(parse_response);
-        Box::new(futures::done(result))
+        let request = request.body(hyper::Body::empty()).unwrap();
+
+        let f = hyper_client
+            .request(request)
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .and_then(|response| {
+                let (parts, body) = response.into_parts();
+                body.concat2()
+                    .map(|body| (parts, body))
+                    .map_err(|e| ApiError(format!("Failed to read response body: {}", e)))
+            })
+            .and_then(|ref x| parse_response(x))
+            .map(|x| ReadCertResponse::Success(x));
+        Box::new(f)
     }
 
-    fn create_orphan_token(&self, param_x_vault_token: String, param_body: models::CreateTokenParameters, context: &Context) -> Box<Future<Item=CreateOrphanTokenResponse, Error=ApiError> + Send> {
-
-
-        let url = format!(
-            "{}/v1/auth/token/create-orphan",
-            self.base_path
-        );
-
+    fn create_orphan_token(
+        &self,
+        param_x_vault_token: String,
+        param_body: models::CreateTokenParameters,
+        context: &Context,
+    ) -> Box<Future<Item = CreateOrphanTokenResponse, Error = ApiError> + Send> {
+        let url = format!("{}/v1/auth/token/create-orphan", self.base_path);
 
         let body = serde_json::to_string(&param_body).expect("impossible to fail to serialize");
 
         let hyper_client = (self.hyper_client)();
-        let request = hyper_client.request(hyper::method::Method::Post, &url);
-        let mut custom_headers = hyper::header::Headers::new();
+        let mut request = Request::post(&url);
 
-        let request = request.body(&body);
-
-        custom_headers.set(ContentType(mimetypes::requests::CREATE_ORPHAN_TOKEN.clone()));
-        context.x_span_id.as_ref().map(|header| custom_headers.set(XSpanId(header.clone())));
-
-        // Header parameters
-        header! { (RequestXVaultToken, "X-Vault-Token") => [String] }
-        custom_headers.set(RequestXVaultToken(param_x_vault_token));
-
-
-        let request = request.headers(custom_headers);
-
-        // Helper function to provide a code block to use `?` in (to be replaced by the `catch` block when it exists).
-        fn parse_response(mut response: hyper::client::response::Response) -> Result<CreateOrphanTokenResponse, ApiError> {
-            match response.status.to_u16() {
-                200 => {
-                    let mut buf = String::new();
-                    response.read_to_string(&mut buf).map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
-                    let body = serde_json::from_str::<models::AuthResponse>(&buf)?;
-
-
-
-                    Ok(CreateOrphanTokenResponse::Success(body))
-                },
-                code => {
-                    let mut buf = [0; 100];
-                    let debug_body = match response.read(&mut buf) {
-                        Ok(len) => match str::from_utf8(&buf[..len]) {
-                            Ok(body) => Cow::from(body),
-                            Err(_) => Cow::from(format!("<Body was not UTF8: {:?}>", &buf[..len].to_vec())),
-                        },
-                        Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
-                    };
-                    Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
-                                         code,
-                                         response.headers,
-                                         debug_body)))
-                }
-            }
-        }
-
-        let result = request.send().map_err(|e| ApiError(format!("No response received: {}", e))).and_then(parse_response);
-        Box::new(futures::done(result))
-    }
-
-    fn create_token(&self, param_x_vault_token: String, param_body: models::CreateTokenParameters, context: &Context) -> Box<Future<Item=CreateTokenResponse, Error=ApiError> + Send> {
-
-
-        let url = format!(
-            "{}/v1/auth/token/create",
-            self.base_path
+        request.header(
+            header::CONTENT_TYPE,
+            mimetypes::requests::CREATE_ORPHAN_TOKEN.clone(),
         );
 
+        if let Some(ref xspan) = context.x_span_id {
+            let x_span_value = HeaderValue::from_str(xspan).unwrap();
+            request.header("x-span-id", x_span_value);
+        }
+
+        // Header parameters
+        request.header(REQUEST_X_VAULT_TOKEN, param_x_vault_token);
+
+        let request = request.body(body.into()).unwrap();
+
+        let f = hyper_client
+            .request(request)
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .and_then(|response| {
+                let (parts, body) = response.into_parts();
+                body.concat2()
+                    .map(|body| (parts, body))
+                    .map_err(|e| ApiError(format!("Failed to read response body: {}", e)))
+            })
+            .and_then(|ref x| parse_response(x))
+            .map(|x| CreateOrphanTokenResponse::Success(x));
+        Box::new(f)
+    }
+
+    fn create_token(
+        &self,
+        param_x_vault_token: String,
+        param_body: models::CreateTokenParameters,
+        context: &Context,
+    ) -> Box<Future<Item = CreateTokenResponse, Error = ApiError> + Send> {
+        let url = format!("{}/v1/auth/token/create", self.base_path);
 
         let body = serde_json::to_string(&param_body).expect("impossible to fail to serialize");
 
         let hyper_client = (self.hyper_client)();
-        let request = hyper_client.request(hyper::method::Method::Post, &url);
-        let mut custom_headers = hyper::header::Headers::new();
+        let mut request = Request::post(&url);
 
-        let request = request.body(&body);
-
-        custom_headers.set(ContentType(mimetypes::requests::CREATE_TOKEN.clone()));
-        context.x_span_id.as_ref().map(|header| custom_headers.set(XSpanId(header.clone())));
-
-        // Header parameters
-        header! { (RequestXVaultToken, "X-Vault-Token") => [String] }
-        custom_headers.set(RequestXVaultToken(param_x_vault_token));
-
-
-        let request = request.headers(custom_headers);
-
-        // Helper function to provide a code block to use `?` in (to be replaced by the `catch` block when it exists).
-        fn parse_response(mut response: hyper::client::response::Response) -> Result<CreateTokenResponse, ApiError> {
-            match response.status.to_u16() {
-                200 => {
-                    let mut buf = String::new();
-                    response.read_to_string(&mut buf).map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
-                    let body = serde_json::from_str::<models::AuthResponse>(&buf)?;
-
-
-
-                    Ok(CreateTokenResponse::Success(body))
-                },
-                code => {
-                    let mut buf = [0; 100];
-                    let debug_body = match response.read(&mut buf) {
-                        Ok(len) => match str::from_utf8(&buf[..len]) {
-                            Ok(body) => Cow::from(body),
-                            Err(_) => Cow::from(format!("<Body was not UTF8: {:?}>", &buf[..len].to_vec())),
-                        },
-                        Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
-                    };
-                    Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
-                                         code,
-                                         response.headers,
-                                         debug_body)))
-                }
-            }
-        }
-
-        let result = request.send().map_err(|e| ApiError(format!("No response received: {}", e))).and_then(parse_response);
-        Box::new(futures::done(result))
-    }
-
-    fn log_in_with_tls_certificate(&self, param_body: Option<models::AuthCertLoginParameters>, context: &Context) -> Box<Future<Item=LogInWithTLSCertificateResponse, Error=ApiError> + Send> {
-
-
-        let url = format!(
-            "{}/v1/auth/cert/login",
-            self.base_path
+        request.header(
+            header::CONTENT_TYPE,
+            mimetypes::requests::CREATE_TOKEN.clone(),
         );
 
-        let body = param_body.map(|ref body| {
+        if let Some(ref xspan) = context.x_span_id {
+            let x_span_value = HeaderValue::from_str(xspan).unwrap();
+            request.header("x-span-id", x_span_value);
+        }
 
-            serde_json::to_string(body).expect("impossible to fail to serialize")
-        });
+        // Header parameters
+        request.header(REQUEST_X_VAULT_TOKEN, param_x_vault_token);
+
+        let request = request.body(body.into()).unwrap();
+
+        let f = hyper_client
+            .request(request)
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .and_then(|response| {
+                let (parts, body) = response.into_parts();
+                body.concat2()
+                    .map(|body| (parts, body))
+                    .map_err(|e| ApiError(format!("Failed to read response body: {}", e)))
+            })
+            .and_then(|ref x| parse_response(x))
+            .map(|x| CreateTokenResponse::Success(x));
+        Box::new(f)
+    }
+
+    fn log_in_with_tls_certificate(
+        &self,
+        param_body: Option<models::AuthCertLoginParameters>,
+        context: &Context,
+    ) -> Box<Future<Item = LogInWithTLSCertificateResponse, Error = ApiError> + Send> {
+        let url = format!("{}/v1/auth/cert/login", self.base_path);
+
+        let body = param_body
+            .map(|ref body| serde_json::to_string(body).expect("impossible to fail to serialize"));
         let hyper_client = (self.hyper_client)();
-        let request = hyper_client.request(hyper::method::Method::Post, &url);
-        let mut custom_headers = hyper::header::Headers::new();
+        let mut request = Request::post(&url);
+
+        request.header(
+            header::CONTENT_TYPE,
+            mimetypes::requests::LOG_IN_WITH_TLS_CERTIFICATE.clone(),
+        );
+
+        if let Some(ref xspan) = context.x_span_id {
+            let x_span_value = HeaderValue::from_str(xspan).unwrap();
+            request.header("x-span-id", x_span_value);
+        }
 
         let request = match body {
-            Some(ref body) => request.body(body),
-            None => request,
+            Some(body) => request.body(body.into()).unwrap(),
+            None => request.body(hyper::Body::empty()).unwrap(),
         };
 
-        custom_headers.set(ContentType(mimetypes::requests::LOG_IN_WITH_TLS_CERTIFICATE.clone()));
-        context.x_span_id.as_ref().map(|header| custom_headers.set(XSpanId(header.clone())));
-
-
-        let request = request.headers(custom_headers);
-
-        // Helper function to provide a code block to use `?` in (to be replaced by the `catch` block when it exists).
-        fn parse_response(mut response: hyper::client::response::Response) -> Result<LogInWithTLSCertificateResponse, ApiError> {
-            match response.status.to_u16() {
-                200 => {
-                    let mut buf = String::new();
-                    response.read_to_string(&mut buf).map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
-                    let body = serde_json::from_str::<models::AuthResponse>(&buf)?;
-
-
-
-                    Ok(LogInWithTLSCertificateResponse::Success(body))
-                },
-                code => {
-                    let mut buf = [0; 100];
-                    let debug_body = match response.read(&mut buf) {
-                        Ok(len) => match str::from_utf8(&buf[..len]) {
-                            Ok(body) => Cow::from(body),
-                            Err(_) => Cow::from(format!("<Body was not UTF8: {:?}>", &buf[..len].to_vec())),
-                        },
-                        Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
-                    };
-                    Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
-                                         code,
-                                         response.headers,
-                                         debug_body)))
-                }
-            }
-        }
-
-        let result = request.send().map_err(|e| ApiError(format!("No response received: {}", e))).and_then(parse_response);
-        Box::new(futures::done(result))
+        let f = hyper_client
+            .request(request)
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .and_then(|response| {
+                let (parts, body) = response.into_parts();
+                body.concat2()
+                    .map(|body| (parts, body))
+                    .map_err(|e| ApiError(format!("Failed to read response body: {}", e)))
+            })
+            .and_then(|ref x| parse_response(x))
+            .map(|x| LogInWithTLSCertificateResponse::Success(x));
+        Box::new(f)
     }
 
-    fn renew_own_token(&self, param_x_vault_token: String, param_body: models::RenewSelfParameters, context: &Context) -> Box<Future<Item=RenewOwnTokenResponse, Error=ApiError> + Send> {
-
-
-        let url = format!(
-            "{}/v1/auth/token/renew-self",
-            self.base_path
-        );
-
+    fn renew_own_token(
+        &self,
+        param_x_vault_token: String,
+        param_body: models::RenewSelfParameters,
+        context: &Context,
+    ) -> Box<Future<Item = RenewOwnTokenResponse, Error = ApiError> + Send> {
+        let url = format!("{}/v1/auth/token/renew-self", self.base_path);
 
         let body = serde_json::to_string(&param_body).expect("impossible to fail to serialize");
 
         let hyper_client = (self.hyper_client)();
-        let request = hyper_client.request(hyper::method::Method::Post, &url);
-        let mut custom_headers = hyper::header::Headers::new();
+        let mut request = Request::post(&url);
 
-        let request = request.body(&body);
+        request.header(
+            header::CONTENT_TYPE,
+            mimetypes::requests::RENEW_OWN_TOKEN.clone(),
+        );
 
-        custom_headers.set(ContentType(mimetypes::requests::RENEW_OWN_TOKEN.clone()));
-        context.x_span_id.as_ref().map(|header| custom_headers.set(XSpanId(header.clone())));
-
-        // Header parameters
-        header! { (RequestXVaultToken, "X-Vault-Token") => [String] }
-        custom_headers.set(RequestXVaultToken(param_x_vault_token));
-
-
-        let request = request.headers(custom_headers);
-
-        // Helper function to provide a code block to use `?` in (to be replaced by the `catch` block when it exists).
-        fn parse_response(mut response: hyper::client::response::Response) -> Result<RenewOwnTokenResponse, ApiError> {
-            match response.status.to_u16() {
-                200 => {
-                    let mut buf = String::new();
-                    response.read_to_string(&mut buf).map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
-                    let body = serde_json::from_str::<models::AuthResponse>(&buf)?;
-
-
-
-                    Ok(RenewOwnTokenResponse::Success(body))
-                },
-                code => {
-                    let mut buf = [0; 100];
-                    let debug_body = match response.read(&mut buf) {
-                        Ok(len) => match str::from_utf8(&buf[..len]) {
-                            Ok(body) => Cow::from(body),
-                            Err(_) => Cow::from(format!("<Body was not UTF8: {:?}>", &buf[..len].to_vec())),
-                        },
-                        Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
-                    };
-                    Err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
-                                         code,
-                                         response.headers,
-                                         debug_body)))
-                }
-            }
+        if let Some(ref xspan) = context.x_span_id {
+            let x_span_value = HeaderValue::from_str(xspan).unwrap();
+            request.header("x-span-id", x_span_value);
         }
 
-        let result = request.send().map_err(|e| ApiError(format!("No response received: {}", e))).and_then(parse_response);
-        Box::new(futures::done(result))
-    }
+        // Header parameters
+        request.header(REQUEST_X_VAULT_TOKEN, param_x_vault_token);
 
+        let request = request.body(body.into()).unwrap();
+
+        let f = hyper_client
+            .request(request)
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .and_then(|response| {
+                let (parts, body) = response.into_parts();
+                body.concat2()
+                    .map(|body| (parts, body))
+                    .map_err(|e| ApiError(format!("Failed to read response body: {}", e)))
+            })
+            .and_then(|ref x| parse_response(x))
+            .map(|x| RenewOwnTokenResponse::Success(x));
+        Box::new(f)
+    }
 }
 
 #[derive(Debug)]
 pub enum ClientInitError {
     InvalidScheme,
-    InvalidUrl(hyper::error::ParseError),
+    InvalidUrl(url::ParseError),
     MissingHost,
-    SslError(openssl::error::ErrorStack)
+    SslError(openssl::error::ErrorStack),
 }
 
-impl From<hyper::error::ParseError> for ClientInitError {
-    fn from(err: hyper::error::ParseError) -> ClientInitError {
+impl From<url::ParseError> for ClientInitError {
+    fn from(err: url::ParseError) -> ClientInitError {
         ClientInitError::InvalidUrl(err)
     }
 }

--- a/vault-api/src/lib.rs
+++ b/vault-api/src/lib.rs
@@ -12,6 +12,10 @@ extern crate lazy_static;
 #[macro_use]
 extern crate log;
 
+extern crate http;
+#[macro_use]
+extern crate mime;
+
 // Logically this should be in the client and server modules, but rust doesn't allow `macro_use` from a module.
 #[cfg(any(feature = "client", feature = "server"))]
 #[macro_use]

--- a/vault-api/src/mimetypes.rs
+++ b/vault-api/src/mimetypes.rs
@@ -1,57 +1,63 @@
 /// mime types for requests and responses
 
+#[cfg(feature = "server")]
 pub mod responses {
-    use hyper::mime::*;
+    extern crate iron;
+    use self::iron::mime::{Mime, TopLevel, SubLevel};
 
     // The macro is called per-operation to beat the recursion limit
     /// Create Mime objects for the response content types for GenerateCert
     lazy_static! {
-        pub static ref GENERATE_CERT_SUCCESS: Mime = mime!(Application/Json);
+        pub static ref GENERATE_CERT_SUCCESS: Mime = Mime(TopLevel::Application, SubLevel::Json, Vec::new());
     }
     /// Create Mime objects for the response content types for ReadCert
     lazy_static! {
-        pub static ref READ_CERT_SUCCESS: Mime = mime!(Application/Json);
+        pub static ref READ_CERT_SUCCESS: Mime = Mime(TopLevel::Application, SubLevel::Json, Vec::new());
     }
     /// Create Mime objects for the response content types for CreateOrphanToken
     lazy_static! {
-        pub static ref CREATE_ORPHAN_TOKEN_SUCCESS: Mime = mime!(Application/Json);
+        pub static ref CREATE_ORPHAN_TOKEN_SUCCESS: Mime = Mime(TopLevel::Application, SubLevel::Json, Vec::new());
     }
     /// Create Mime objects for the response content types for CreateToken
     lazy_static! {
-        pub static ref CREATE_TOKEN_SUCCESS: Mime = mime!(Application/Json);
+        pub static ref CREATE_TOKEN_SUCCESS: Mime = Mime(TopLevel::Application, SubLevel::Json, Vec::new());
     }
     /// Create Mime objects for the response content types for RenewOwnToken
     lazy_static! {
-        pub static ref RENEW_OWN_TOKEN_SUCCESS: Mime = mime!(Application/Json);
+        pub static ref RENEW_OWN_TOKEN_SUCCESS: Mime = Mime(TopLevel::Application, SubLevel::Json, Vec::new());
     }
 
 }
 
 pub mod requests {
-    use hyper::mime::*;
+    use mime::{APPLICATION_JSON, Mime};
+    use hyper::header::HeaderValue;
+
+    use http;
+
    /// Create Mime objects for the request content types for SysLeasesRevokePut
     lazy_static! {
-        pub static ref SYS_LEASES_REVOKE_PUT: Mime = mime!(Application/Json);
+        pub static ref SYS_LEASES_REVOKE_PUT: HeaderValue = HeaderValue::from_str(APPLICATION_JSON.as_ref()).unwrap();
     }
    /// Create Mime objects for the request content types for GenerateCert
     lazy_static! {
-        pub static ref GENERATE_CERT: Mime = mime!(Application/Json);
+        pub static ref GENERATE_CERT: HeaderValue = HeaderValue::from_str(APPLICATION_JSON.as_ref()).unwrap();
     }
    /// Create Mime objects for the request content types for CreateOrphanToken
     lazy_static! {
-        pub static ref CREATE_ORPHAN_TOKEN: Mime = mime!(Application/Json);
+        pub static ref CREATE_ORPHAN_TOKEN: HeaderValue = HeaderValue::from_str(APPLICATION_JSON.as_ref()).unwrap();
     }
    /// Create Mime objects for the request content types for CreateToken
     lazy_static! {
-        pub static ref CREATE_TOKEN: Mime = mime!(Application/Json);
+        pub static ref CREATE_TOKEN: HeaderValue = HeaderValue::from_str(APPLICATION_JSON.as_ref()).unwrap();
     }
    /// Create Mime objects for the request content types for LogInWithTLSCertificate
     lazy_static! {
-        pub static ref LOG_IN_WITH_TLS_CERTIFICATE: Mime = mime!(Application/Json);
+        pub static ref LOG_IN_WITH_TLS_CERTIFICATE: HeaderValue = HeaderValue::from_str(APPLICATION_JSON.as_ref()).unwrap();
     }
    /// Create Mime objects for the request content types for RenewOwnToken
     lazy_static! {
-        pub static ref RENEW_OWN_TOKEN: Mime = mime!(Application/Json);
+        pub static ref RENEW_OWN_TOKEN: HeaderValue = HeaderValue::from_str(APPLICATION_JSON.as_ref()).unwrap();
     }
 
 }


### PR DESCRIPTION
- Migrated the client and server part to hyper v12
  - Mime is no longer part of hyper -> added the mime crate
  - Headers are no longer part of hyper -> added the http crate
  - Updated hyper-openssl since the `HttpsConnector` now expects a `SslConnector`
  - Now using reexported hyper modules in the server / mimetypes part in order to be able to make the iron part work
  - Had to remove the `header!` macro since it's no longer part of hyper.
 
Missing:
The examples are not yet fixed entirely. Major problem I had here was that `iron` still uses hyper v10, I assume the best way to fix that and avoid future problems is to extract the server part to a new crate and continue using hyper v10 for the server part. The alternative would be to use a plain hyper server implementation, which might be an even better idea.

Furthermore I haven't had the chance to really test this yet, but I thought it would still make sense to spare you some of the work. 